### PR TITLE
BS-X: Allow erasing locked flash pages (deassert /WP)

### DIFF
--- a/src/cores/Satellaview.cpp
+++ b/src/cores/Satellaview.cpp
@@ -433,6 +433,7 @@ namespace OSCR::Cores::Satellaview
 
     //Disable 8M memory pack write protection
     writeBank(0x0C, 0x5000, 0x80);  //Modify write enable register
+    writeBank(0x0D, 0x5000, 0x80);  //Deassert flash /WP line (allow erasing locked pages)
     writeBank(0x0E, 0x5000, 0x80);  //Commit register modification
 
     OSCR::UI::printSync(FS(OSCR::Strings::Status::Erasing));


### PR DESCRIPTION
(Part of solution to #13)

If the flash IC inside a Satellaview memory pack has locked pages for whatever reason, it won't be possible to erase them if the `/WP` signal is asserted.  The BS-X MCC provides a register to control the `/WP` signal (0D:5000).

Curiously, the operation of this register is tied to a successful CIC unlock so a CIC is mandatory to make use of it.